### PR TITLE
Added support for brightness parameter (will be black otherwise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ exports = {
      * @param numLeds {Number}  number of LEDs to be controlled
      * @param [options] {Object}  (acutally only tested with default-values)
      *                            intialization-options for the library
-     *                            (PWM frequency, DMA channel, GPIO)
+     *                            (PWM frequency, DMA channel, GPIO, Brightness)
      */
     init: function(numLeds, options) {},
 

--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -65,10 +65,12 @@ Handle<Value> Init(const Arguments& args) {
   channel0data.gpionum = DEFAULT_GPIO_PIN;
   channel0data.invert = 0;
   channel0data.count = 0;
+  channel0data.brightness = 255;
 
   channel1data.gpionum = 0;
   channel1data.invert = 0;
   channel1data.count = 0;
+  channel1data.brightness = 255;
 
 
   ledstring.channel[0] = channel0data;
@@ -95,7 +97,8 @@ Handle<Value> Init(const Arguments& args) {
         symFreq = String::NewSymbol("frequency"),
         symDmaNum = String::NewSymbol("dmaNum"),
         symGpioPin = String::NewSymbol("gpioPin"),
-        symInvert = String::NewSymbol("invert");
+        symInvert = String::NewSymbol("invert"),
+        symBrightness = String::NewSymbol("brightness");
 
     if(config->HasOwnProperty(symFreq)) {
       ledstring.freq = config->Get(symFreq)->Uint32Value();
@@ -111,6 +114,10 @@ Handle<Value> Init(const Arguments& args) {
 
     if(config->HasOwnProperty(symInvert)) {
       ledstring.channel[0].invert = config->Get(symInvert)->Int32Value();
+    }
+
+    if(config->HasOwnProperty(symBrightness)) {
+      ledstring.channel[0].brightness = config->Get(symBrightness)->Int32Value();
     }
   }
 


### PR DESCRIPTION
This patch is necessary when the subproject rpi-ws281x is updated to the current version. This new verison introduces a brightness parameter, 0-255, defaulting to 0 --> everything is black. This patch changes the default to full brightness and exposes the brightness parameter to JavaScript.

Unless the subproject is updated it will probably fail to compile.