### PR TITLE
Rpi 2 Fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/rpi_ws281x"]
 	path = src/rpi_ws281x
-	url = git@github.com:jgarff/rpi_ws281x.git
+	url = git@github.com:richardghirst/rpi_ws281x.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,9 @@
           'sources': [
             './src/rpi_ws281x/ws2811.c',
             './src/rpi_ws281x/pwm.c',
-            './src/rpi_ws281x/dma.c'
+            './src/rpi_ws281x/dma.c',
+            './src/rpi_ws281x/mailbox.c',
+            './src/rpi_ws281x/board_info.c'
           ],
           'cflags': ['-O2', '-Wall']
         },

--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -6,14 +6,14 @@ function getNativeBindings() {
     // test for matches the raspberry-pi before loading the native-module
     if(process.arch === 'arm' || process.platform === 'linux') {
 
-        // will only work on the Broadcom BCM2708
-        var isBCM2708 = (function() {
+        // will only work on the Broadcom BCM2709
+        var isBCM2708_9 = (function() {
             var cpuInfo = require('fs').readFileSync('/proc/cpuinfo').toString();
 
-            return /hardware\s*:\s*bcm2708/i.test(cpuInfo);
+            return /hardware\s*:\s*bcm2708/i.test(cpuInfo) || /hardware\s*:\s*bcm2709/i.test(cpuInfo);
         } ());
 
-        if(isBCM2708) {
+        if(isBCM2708_9) {
             return require('./binding/rpi_ws281x.node');
         }
     }


### PR DESCRIPTION
Updated to work with Rpi 2 - based on richardghirsts fork of jgarffs rpi_ws281x.git library

No idea if this fork will work with the original Pi.